### PR TITLE
fix(ask-teacher): 移除教师提问箱链接中文后缀

### DIFF
--- a/src/router/routes/modules/student-page/askTeacher.ts
+++ b/src/router/routes/modules/student-page/askTeacher.ts
@@ -28,7 +28,7 @@ export const AskTeacherRoute: AppRouteRecordRaw = {
             },
         },
         {
-            path: ':teacher_id/:teacher_name',
+            path: ':teacher_id/:teacher_name?',
             name: 'AskTeacherDetail',
             meta: {
                 NoAlive: true,

--- a/src/views/ask-teacher/AskTeacher.vue
+++ b/src/views/ask-teacher/AskTeacher.vue
@@ -67,6 +67,7 @@ import { SyncStore } from '@/store/modules/question-detail'
 import { DeviceTypeStore } from '@/store/modules/device-type'
 import { ComposeDialogStore } from '@/store/modules/compose-dialog'
 import ComposeDialog from '@/components/compose/ComposeDialog.vue'
+import { getUserByIdApi } from '@/api/user/user.api'
 import {
     questionList,
     InitStatus,
@@ -260,9 +261,32 @@ const handleQuestionPosted = (question: QuestionItem) => {
 //     }
 // );
 
-onMounted(() => {
+const getRouteParam = (param: unknown) => {
+    if (Array.isArray(param)) {
+        return param[0]
+    }
+    return typeof param === 'string' ? param : ''
+}
+
+const resolveTeacherName = async () => {
+    const routeTeacherName = getRouteParam(route.params.teacher_name)
+    if (routeTeacherName) {
+        teacherName.value = routeTeacherName
+        return
+    }
+
+    teacherName.value = '老师'
+    try {
+        const teacher = await getUserByIdApi(String(teacherId.value))
+        teacherName.value = teacher?.name || teacher?.nickname || '老师'
+    } catch {
+        teacherName.value = '老师'
+    }
+}
+
+onMounted(async () => {
     teacherId.value = Number(route.params.teacher_id)
-    teacherName.value = String(route.params.teacher_name)
+    await resolveTeacherName()
     document.title = `${teacherName.value}的提问箱`
     Init()
 })

--- a/src/views/ask-teacher/TeacherQuestionBox.vue
+++ b/src/views/ask-teacher/TeacherQuestionBox.vue
@@ -182,7 +182,7 @@ const navigateTo = (key: any) => {
         return
     } else {
         router.push({
-            path: `/ask-teacher/${key.teacherId}/${key.teacherName}`,
+            path: `/ask-teacher/${key.teacherId}`,
         })
     }
 }


### PR DESCRIPTION
## Summary
- Generate ask-teacher links without the teacher-name suffix so QR links use `/ask-teacher/:teacher_id`.
- Keep legacy `/ask-teacher/:teacher_id/:teacher_name` links working with an optional route param.
- Resolve the teacher name from the existing user info API when the canonical URL has no name suffix.

## Test plan
- [x] `npm run type-check`
- [x] `npm run build`
- [x] Local Vite requests returned 200 for `/ask-teacher/128` and `/ask-teacher/128/蓝晓婷`
- [ ] Browser click smoke test not completed because Chrome automation was not connected